### PR TITLE
allow cloning a git repo using https credentials

### DIFF
--- a/model/bits.go
+++ b/model/bits.go
@@ -13,12 +13,14 @@ type MinioObject struct {
 	URL           string   `yaml:"url"`
 	ProductSlug   string   `yaml:"productSlug"`
 	ProductFamily string   `yaml:"productFamily"`
-	Globs        []string  `yaml:"globs"`
+	Globs         []string `yaml:"globs"`
 	Version       string   `yaml:"version"`
 	ImageName     string   `yaml:"imageName"`
 	Tag           string   `yaml:"tag"`
 	GitRepo       string   `yaml:"gitRepo"`
 	Branch        string   `yaml:"branch"`
+	GitUser       string   `yaml:"gitUser"`
+	GitPassword   string   `yaml:"gitPassword"`
 }
 
 type Bom struct {


### PR DESCRIPTION
* add a user/pass to the git type
* use go-git to clone https using either creds or not
* turn the clone into a tarball
* ensure we end up with a tarball that looks like those downloaded from github

You can now add a section to the bits yaml like this, and downloading will result in a tarball matching what would be downloaded using the `git` resourceType

```
bits:
- name: nsx-t-gen-pipeline-tarball.tgz
  contentType: application/gzip
  resourceType: gitclone
  branch: nsxt-2.1
  gitRepo: https://gitlab.eng.vmware.com/ps-emerging/nsx-t-gen
  gitUser: tscanlan
  gitPassword: XXXX
```